### PR TITLE
Tokenizer bug fix - use tokenizer_encode given as input to PromptDataset

### DIFF
--- a/toolformer_pytorch/toolformer_pytorch.py
+++ b/toolformer_pytorch/toolformer_pytorch.py
@@ -547,6 +547,7 @@ class PromptDataset(Dataset):
         self.data = data
         self.prompt = prompt
         self.prompt_input_tag_regex = re.escape(prompt_input_tag)
+        self.tokenizer_encode = tokenizer_encode
 
     def __len__(self):
         return len(self.data)
@@ -554,7 +555,7 @@ class PromptDataset(Dataset):
     def __getitem__(self, idx):
         data_string = self.data[idx]
         data_with_prompt = re.sub(self.prompt_input_tag_regex, data_string, self.prompt)
-        token_ids = tokenizer.encode(data_with_prompt)
+        token_ids = self.tokenizer_encode(data_with_prompt)
         return torch.tensor(token_ids).long(), torch.tensor(len(token_ids)).long()
 
 def prompt_collate_fn(data, padding_value = 0):


### PR DESCRIPTION
Summary: Use `tokenizer_encode` given as input to `PromptDataset`, instead of default tokenizer (small bug fix).